### PR TITLE
Update k8s-deviceplugin to 0.2.0 ahead of release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "k8s-deviceplugin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "prost",
  "tonic",

--- a/k8s-deviceplugin/Cargo.toml
+++ b/k8s-deviceplugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-deviceplugin"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 authors = ["hasheddan <georgedanielmangum@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
Updates k8s-deviceplugin version to 0.2.0 ahead of tag and release.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>